### PR TITLE
Hack for aggregate maps and YAML support for zone file

### DIFF
--- a/src/xtgeoapp_grd3dmaps/aggregate/_grid_aggregation.py
+++ b/src/xtgeoapp_grd3dmaps/aggregate/_grid_aggregation.py
@@ -296,10 +296,9 @@ def _property_to_map(
     assert weights is None or weights.shape == prop.shape
     if weights is not None:
         assert method in [AggregationMethod.MEAN, AggregationMethod.SUM]
-    if True:
-        data = prop[0][cols] # Necessary change for the code to work
-    else:
-        data = prop[cols]
+    data = prop[0][cols] if len(prop) == 1 else prop[cols]
+    # Small hack due to a slight difference between calculating mass and other properties
+    # TODO: Implement a better solution
     weights = np.ones_like(data) if weights is None else weights[cols]
     if data.mask.any():
         invalid = data.mask

--- a/src/xtgeoapp_grd3dmaps/aggregate/_parser.py
+++ b/src/xtgeoapp_grd3dmaps/aggregate/_parser.py
@@ -207,6 +207,19 @@ def _zonation_from_zproperty(
     grid: xtgeo.Grid,
     zproperty: ZProperty
 ) -> List[Tuple[str, np.ndarray]]:
+    if zproperty.source.split(".")[-1] in ["yml", "yaml"]:
+        with open(zproperty.source, "r", encoding="utf8") as stream:
+            try:
+                zfile = yaml.safe_load(stream)
+            except yaml.YAMLError as exc:
+                print(exc)
+                exit()
+        if 'zranges' not in zfile:
+            error_text = ("The yaml zone file must be in the format:\nzranges:\
+            \n    - Zone1: [1, 5]\n    - Zone2: [6, 10]\n    - Zone3: [11, 14])")
+            raise InputError(error_text)
+        zranges = zfile['zranges']
+        return _zonation_from_zranges(grid, zranges)
     actnum = grid.actnum_indices
     prop = xtgeo.gridproperty_from_file(
         zproperty.source, grid=grid, name=zproperty.name


### PR DESCRIPTION
Small (temporary) hack that handles the issue in aggregate maps where a list is a level deeper when calculating mass maps. Also added support for YAML file as the source zone file listed in the config file.